### PR TITLE
Support old format php session

### DIFF
--- a/src/main/java/de/ailis/pherialize/Serializer.java
+++ b/src/main/java/de/ailis/pherialize/Serializer.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import de.ailis.pherialize.exceptions.SerializeException;
 
@@ -89,6 +90,32 @@ public class Serializer
         buffer = new StringBuffer();
         serializeObject(object, buffer);
         return buffer.toString();
+    }
+    
+    /**
+     * Serializes the php session.
+     *
+     * @param object
+     *            The object
+     * @return The serialized data
+     */
+
+    public String serializeSession(final MixedArray array)
+    {
+    	StringBuffer result = new StringBuffer();
+        StringBuffer buffer = new StringBuffer();
+        Iterator<Entry<Object, Object>> items = array.entrySet().iterator();
+		while(items.hasNext())
+		{
+			Entry thisEntry = (Entry) items.next();
+			String key = thisEntry.getKey().toString();
+			
+			buffer.setLength(0);
+			serializeObject(thisEntry.getValue(), buffer);
+			result.append(key + "|" + buffer.toString());
+		}
+        
+        return result.toString();
     }
 
 

--- a/src/main/java/de/ailis/pherialize/Unserializer.java
+++ b/src/main/java/de/ailis/pherialize/Unserializer.java
@@ -82,6 +82,30 @@ public class Unserializer
         this.history = new ArrayList<Object>();
     }
 
+    /**
+     * Unserializes the session in the data stream.
+     *
+     * @return The unserialized session
+     */
+
+    public Mixed unserializeSession()
+    {
+        MixedArray array;
+        Mixed result;
+        int sep;
+
+        array = new MixedArray();
+        result = new Mixed(array);
+        while ((sep = this.data.indexOf('|', this.pos)) > -1)
+        {
+            String unencoded = this.data.substring(pos, sep);
+            Mixed key = new Mixed(encode(unencoded, charset));
+            this.pos = sep + 1;
+            Mixed value = unserializeObject();
+            array.put(key, value);
+        }
+        return result;
+    }
 
     /**
      * Unserializes the next object in the data stream.

--- a/src/test/java/de/ailis/pherialize/SerializerTest.java
+++ b/src/test/java/de/ailis/pherialize/SerializerTest.java
@@ -416,4 +416,23 @@ public class SerializerTest extends TestCase
         s2 = Pherialize.serialize(array);
         assertEquals(s1, s2);
     }
+    
+    /**
+     * Test serializing array
+     */
+
+    public void testSerializePhpSession()
+    {
+        MixedArray array;
+        String s1, s2;
+
+        array = new MixedArray();
+        array.put("flash_time", null);
+        array.put("created", 1522666956);
+        array.put("email", "email@gmail.com");
+
+        s1 = "flash_time|N;created|i:1522666956;email|s:15:\"email@gmail.com\";";
+        s2 = Pherialize.serializeSession(array);
+        assertEquals(s1, s2);
+    }
 }

--- a/src/test/java/de/ailis/pherialize/UnserializerTest.java
+++ b/src/test/java/de/ailis/pherialize/UnserializerTest.java
@@ -143,6 +143,22 @@ public class UnserializerTest extends TestCase
         assertEquals(new Mixed(Boolean.TRUE), test.get("key2"));
     }
 
+    /**
+     * Tests unserializing a session
+     */
+
+    public void testUnserializeSession()
+    {
+        MixedArray test;
+
+        test = Pherialize.unserializeSession(
+                "login_ok|b:1;nome|s:4:\"sica\";inteiro|i:34;").toArray();
+        assertEquals(3, test.size());
+        assertEquals(new Mixed(Boolean.TRUE), test.get("login_ok"));
+        assertEquals(new Mixed("sica"), test.get("nome"));
+        assertEquals(new Mixed(Integer.valueOf(34)), test.get("inteiro"));
+    }
+
 
     /**
      * Tests unserializing a List


### PR DESCRIPTION
Php had sessions format like this (by default):
`password|s:32:"13ab0e4ebf116c16f7b1331d7c7bed52";mode|s:2:"ba";last_visit|i:1522666956;`
I added support for serialization and deserialization of this format.